### PR TITLE
Rename Default -> Java Byte Code (Default) for Ctrl-Shift-P accessibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ JBE (Java Bytecode Editor)
 Version
 =======
 
-1.0.4
+1.0.5
 
 Installation
 =============

--- a/java-bytecode.tmLanguage
+++ b/java-bytecode.tmLanguage
@@ -7,7 +7,7 @@
 		<string>javap</string>
 	</array>
 	<key>name</key>
-	<string>Default</string>
+	<string>Java Byte Code (Default)</string>
 	<key>patterns</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Currently, Java Byte Code highlighting can be enabled using Ctrl-Shift-P: "Set Syntax: Default", this isn't descriptive without the context menu in the lower right corner.

I have renamed it to include "Java Byte Code".